### PR TITLE
fix(pkg.jenkins.io) avoid AH02032 on the pkg.origin.jenkins.io

### DIFF
--- a/services.tf
+++ b/services.tf
@@ -112,6 +112,7 @@ resource "fastly_service_vcl" "pkg" {
     ssl_sni_hostname      = "pkg.origin.jenkins.io"
     use_ssl               = true
     weight                = 100
+    override_host         = "pkg.origin.jenkins.io" # Avoid AH02032 (SNI set to "pkg.origin.jenkins.io" but host set to "pkg.jenkins.io")
   }
 
   healthcheck {


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3020

If the "Host" header is not overriden, then the VM hosting `pkg.origin.jenkins.io` receives incoming request where the SNI and the hostname mismatches.

When we worked on https://github.com/jenkins-infra/helpdesk/issues/3020 (PRs https://github.com/jenkins-infra/jenkins-infra/pull/2231, https://github.com/jenkins-infra/jenkins-infra/pull/2236 and https://github.com/jenkins-infra/jenkins-infra/pull/2237), we caused outage on the whole pkg.jenkins.io which was sending HTTP/421 errors becauses of this: Apache was cutting the TLS handshakes because of this mismatch.

It does not happen on the other fastly services defined in this file because their origin backends are in a Kubernetes cluster with an nginx ingress which uses only the SNI https://docs.nginx.com/nginx/admin-guide/security-controls/terminating-ssl-http/ (and https://serverfault.com/questions/907961/nginx-responds-with-200-even-when-http-host-header-is-different-from-sni).