### PR TITLE
feat(www.jenkins.io) force SSL to avoid downgrading to HTTP

### DIFF
--- a/services.tf
+++ b/services.tf
@@ -39,6 +39,15 @@ resource "fastly_service_vcl" "jenkinsio" {
     window            = 2
   }
 
+  request_setting {
+    bypass_busy_wait = false
+    force_miss       = false
+    force_ssl        = true
+    max_stale_age    = 0
+    name             = "Force SSL"
+    timer_support    = false
+  }
+
   gzip {
     content_types = var.gzip_content_types
     extensions    = var.gzip_extensions

--- a/services.tf
+++ b/services.tf
@@ -14,7 +14,7 @@ resource "fastly_service_vcl" "jenkinsio" {
     connect_timeout       = 1000
     error_threshold       = 0
     first_byte_timeout    = 15000
-    healthcheck           = "public.aks.jenkins.io"
+    healthcheck           = "public.publick8s.jenkins.io"
     max_conn              = 200
     name                  = "www.origin.jenkins.io"
     port                  = 443
@@ -32,7 +32,7 @@ resource "fastly_service_vcl" "jenkinsio" {
     http_version      = "1.1"
     initial           = 1
     method            = "GET"
-    name              = "public.aks.jenkins.io"
+    name              = "public.publick8s.jenkins.io"
     path              = "/"
     threshold         = 1
     timeout           = 5000
@@ -306,6 +306,6 @@ resource "fastly_service_vcl" "stories" {
 }
 
 resource "fastly_tls_subscription" "stories" {
-  domains = [for domain in fastly_service_vcl.stories.domain : domain.name]
+  domains               = [for domain in fastly_service_vcl.stories.domain : domain.name]
   certificate_authority = "lets-encrypt"
 }


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3686, this PR adds a settings set for requests on the www.jenkins.io CDN-ized service.

This "request settings set" forces SSL redirection: it's the same as for pkg.jenkins.io which never downgrades to HTTPS:

```
$ curl -v https://pkg.jenkins.io/debian 2>&1 | grep -i location: 
< location: https://pkg.origin.jenkins.io/debian/      # Keeps HTTPS
```

cc @Wadeck for info

----

Minor chore added to this PR in a second commit as I'm lazy to author a 2nd PR