### PR TITLE
chore: bump Terraform to 1.9.x

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -4,10 +4,7 @@
 provider "registry.terraform.io/fastly/fastly" {
   version = "5.11.0"
   hashes = [
-    "h1:AjSmD1TYeeJnds4MqN/4Ty7XA4soYbYcTUUJ7pgEO90=",
-    "h1:JtC/+gfu419ceeDUajiKKdzKMGz35W+0slW6TIlnHJY=",
     "h1:kv4rW+6dyoJHxbZswm0vC4+e96D7NlzGo/sa6Psr4hU=",
-    "h1:qLsiQxIENCiBQZghDHvOclOTYiZSVWR/PJUxIJwt2Vk=",
     "zh:0a209382e7644ceb6d0c871109cb730e772ac436f63a5c5814d12a476cc72986",
     "zh:38efbb97d1aa2ae056fd9f8189a4773e29140af4a2a6d42fa37ae67a549c7649",
     "zh:59bc24ff24197fd1bf428aa6ac213ea07ddea9ca33f71c3916578c7983e834c6",
@@ -29,9 +26,6 @@ provider "registry.terraform.io/hashicorp/local" {
   version = "2.5.1"
   hashes = [
     "h1:/GAVA/xheGQcbOZEq0qxANOg+KVLCA7Wv8qluxhTjhU=",
-    "h1:8oTPe2VUL6E2d3OcrvqyjI4Nn/Y/UEQN26WLk5O/B0g=",
-    "h1:fm2EuMlsdPTuv2tKwx3PMJzWJUh7aMtU9Eky7t4fMys=",
-    "h1:tjcGlQAFA0kmQ4vKkIPPUC4it1UYxLbg4YvHOWRAJHA=",
     "zh:0af29ce2b7b5712319bf6424cb58d13b852bf9a777011a545fac99c7fdcdf561",
     "zh:126063ea0d79dad1f68fa4e4d556793c0108ce278034f101d1dbbb2463924561",
     "zh:196bfb49086f22fd4db46033e01655b0e5e036a5582d250412cc690fa7995de5",

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.6, <1.7"
+  required_version = ">= 1.9, <1.10"
   required_providers {
     fastly = {
       source = "fastly/fastly"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4164

This PR bumps Terraform to 1.9.x and shared tools to their latest version