### PR TITLE
chore: separate updatecli to its own pipeline

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,23 +1,12 @@
-parallel(
-  failFast: false,
-  'terraform': {
-    terraform(
-      // "Read only" token
-      stagingCredentials: [
-        string(variable: 'FASTLY_API_KEY', credentialsId:'staging-terraform-fastly-api-key'),
-        file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'staging-terraform-fastly-backend-config'),
-      ],
-      // "Read write" token
-      productionCredentials: [
-        string(variable: 'FASTLY_API_KEY', credentialsId:'production-terraform-fastly-api-key'),
-        file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'production-terraform-fastly-backend-config'),
-      ],
-    )
-  },
-  'updatecli': {
-    updatecli(action: 'diff')
-    if (env.BRANCH_IS_PRIMARY) {
-      updatecli(action: 'apply', cronTriggerExpression: '@daily')
-    }
-  },
+terraform(
+  // "Read only" token
+  stagingCredentials: [
+    string(variable: 'FASTLY_API_KEY', credentialsId:'staging-terraform-fastly-api-key'),
+    file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'staging-terraform-fastly-backend-config'),
+  ],
+  // "Read write" token
+  productionCredentials: [
+    string(variable: 'FASTLY_API_KEY', credentialsId:'production-terraform-fastly-api-key'),
+    file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'production-terraform-fastly-backend-config'),
+  ],
 )

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,3 +1,8 @@
+if (env.BRANCH_IS_PRIMARY) {
+    // Only trigger a daily check on the principal branch
+    properties([pipelineTriggers([cron('@daily')])])
+}
+
 terraform(
   // "Read only" token
   stagingCredentials: [
@@ -9,4 +14,5 @@ terraform(
     string(variable: 'FASTLY_API_KEY', credentialsId:'production-terraform-fastly-api-key'),
     file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'production-terraform-fastly-backend-config'),
   ],
+  // publishReports: ['jenkins-infra-data-reports/fastly.json'],
 )

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,0 +1,4 @@
+updatecli(action: 'diff')
+if (env.BRANCH_IS_PRIMARY) {
+    updatecli(action: 'apply', cronTriggerExpression: '@daily')
+}

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,4 +1,7 @@
 updatecli(action: 'diff')
+
 if (env.BRANCH_IS_PRIMARY) {
-    updatecli(action: 'apply', cronTriggerExpression: '@daily')
+    // Only trigger a daily check on the principal branch
+    properties([pipelineTriggers([cron('@daily')])])
+    updatecli(action: 'apply')
 }

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,6 +1,7 @@
+---
 github:
-  user: "Jenkins Infra Bot (updatecli)"
-  email: "60776566+jenkins-infra-bot@users.noreply.github.com"
+  user: "jenkins-infra-updatecli"
+  email: "178728+jenkins-infra-updatecli[bot]@users.noreply.github.com"
   username: "jenkins-infra-bot"
   token: "UPDATECLI_GITHUB_TOKEN"
   branch: "main"

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -2,7 +2,6 @@
 github:
   user: "jenkins-infra-updatecli"
   email: "178728+jenkins-infra-updatecli[bot]@users.noreply.github.com"
-  username: "jenkins-infra-bot"
   token: "UPDATECLI_GITHUB_TOKEN"
   branch: "main"
   owner: "jenkins-infra"


### PR DESCRIPTION
This PR separates updatecli to its own pipeline and uses https://github.com/apps/jenkins-infra-updatecli instead of https://github.com/jenkins-infra-bot in updatecli values.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2778