### PR TITLE
chore: Bump Terraform from 1.9.x to 1.10.x

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.9, <1.10"
+  required_version = ">= 1.10, <1.11"
   required_providers {
     fastly = {
       source = "fastly/fastly"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4465