### PR TITLE
feat(services) enforce authentication for PURGE requests

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,4 @@
+provider "fastly" {
+  # Providers expects an API key specified with the 'FASTLY_API_KEY' environment variable
+  # Ref. https://registry.terraform.io/providers/fastly/fastly/latest/docs#environment-variables
+}

--- a/services.tf
+++ b/services.tf
@@ -94,6 +94,24 @@ resource "fastly_service_vcl" "jenkinsio" {
     priority = 100
     type     = "recv"
   }
+
+  # Requires authentication for purge requests
+  condition {
+    name      = "Purge"
+    priority  = 10
+    statement = "req.request == \"FASTLYPURGE\""
+    type      = "REQUEST"
+  }
+  header {
+    action            = "set"
+    destination       = "http.Fastly-Purge-Requires-Auth"
+    ignore_if_set     = false
+    name              = "Fastly Purge"
+    priority          = 10
+    request_condition = "Purge"
+    source            = "\"1\""
+    type              = "request"
+  }
 }
 
 # pkg.jenkins.io
@@ -154,6 +172,24 @@ resource "fastly_service_vcl" "pkg" {
     priority      = 100
     source        = "\"max-age=300\""
     type          = "response"
+  }
+
+  # Requires authentication for purge requests
+  condition {
+    name      = "Purge"
+    priority  = 10
+    statement = "req.request == \"FASTLYPURGE\""
+    type      = "REQUEST"
+  }
+  header {
+    action            = "set"
+    destination       = "http.Fastly-Purge-Requires-Auth"
+    ignore_if_set     = false
+    name              = "Fastly Purge"
+    priority          = 10
+    request_condition = "Purge"
+    source            = "\"1\""
+    type              = "request"
   }
 }
 
@@ -229,6 +265,24 @@ resource "fastly_service_vcl" "plugins" {
     priority      = 100
     source        = "\"max-age=31557600\""
     type          = "response"
+  }
+
+  # Requires authentication for purge requests
+  condition {
+    name      = "Purge"
+    priority  = 10
+    statement = "req.request == \"FASTLYPURGE\""
+    type      = "REQUEST"
+  }
+  header {
+    action            = "set"
+    destination       = "http.Fastly-Purge-Requires-Auth"
+    ignore_if_set     = false
+    name              = "Fastly Purge"
+    priority          = 10
+    request_condition = "Purge"
+    source            = "\"1\""
+    type              = "request"
   }
 }
 
@@ -307,6 +361,24 @@ resource "fastly_service_vcl" "stories" {
     priority      = 100
     source        = "\"max-age=31557600\""
     type          = "response"
+  }
+
+  # Requires authentication for purge requests
+  condition {
+    name      = "Purge"
+    priority  = 10
+    statement = "req.request == \"FASTLYPURGE\""
+    type      = "REQUEST"
+  }
+  header {
+    action            = "set"
+    destination       = "http.Fastly-Purge-Requires-Auth"
+    ignore_if_set     = false
+    name              = "Fastly Purge"
+    priority          = 10
+    request_condition = "Purge"
+    source            = "\"1\""
+    type              = "request"
   }
 }
 
@@ -391,6 +463,24 @@ resource "fastly_service_vcl" "contributors" {
     source        = "\"max-age=31557600\""
     type          = "response"
   }
+
+  # Requires authentication for purge requests
+  condition {
+    name      = "Purge"
+    priority  = 10
+    statement = "req.request == \"FASTLYPURGE\""
+    type      = "REQUEST"
+  }
+  header {
+    action            = "set"
+    destination       = "http.Fastly-Purge-Requires-Auth"
+    ignore_if_set     = false
+    name              = "Fastly Purge"
+    priority          = 10
+    request_condition = "Purge"
+    source            = "\"1\""
+    type              = "request"
+  }
 }
 
 resource "fastly_tls_subscription" "contributors" {
@@ -473,6 +563,24 @@ resource "fastly_service_vcl" "docs" {
     priority      = 100
     source        = "\"max-age=31557600\""
     type          = "response"
+  }
+
+  # Requires authentication for purge requests
+  condition {
+    name      = "Purge"
+    priority  = 10
+    statement = "req.request == \"FASTLYPURGE\""
+    type      = "REQUEST"
+  }
+  header {
+    action            = "set"
+    destination       = "http.Fastly-Purge-Requires-Auth"
+    ignore_if_set     = false
+    name              = "Fastly Purge"
+    priority          = 10
+    request_condition = "Purge"
+    source            = "\"1\""
+    type              = "request"
   }
 }
 


### PR DESCRIPTION
Following https://www.fastly.com/documentation/guides/concepts/edge-state/cache/purging/, this PR ensures that `PURGE` requests against our Fastly CDN services are refused unless proper authentication is provided (through a Fastly API token).

It requires the following changes (to avoid breaking production deployments):
  - https://github.com/jenkins-infra/jenkins.io/pull/8283 
  - https://github.com/jenkins-infra/charts-secrets/commit/a753cbdeff8ebfd5bc01f7dddc7ae981e90505a6
  - https://github.com/jenkins-infra/charts-secrets/commit/ce2419f69d7ca8733d396056e5020cfc406cf926
  - https://github.com/jenkins-infra/kubernetes-management/pull/6809