### PR TITLE
chore(backends) use clear-text backend config with only the `ARM_CLIENT_SECRET` as credential

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,6 @@
 # .tfstate files
 *.tfstate
 *.tfstate.*
-
-# # Backend config
-backend-config
-
-# Crash log files
 crash.log
 
 # Ignore any .tfvars files that are generated automatically for each Terraform run. Most

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -2,10 +2,10 @@ terraform(
   cronTriggerExpression: env.BRANCH_IS_PRIMARY ? '@daily' : '',
   stagingCredentials: [
     string(variable: 'FASTLY_API_KEY', credentialsId:'staging-terraform-fastly-api-key'),
-    file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'staging-terraform-fastly-backend-config'),
+    string(variable: 'TF_BACKEND_ARM_CLIENT_SECRET', credentialsId:'staging-terraform-fastly-backend-config-arm-secret'),
   ],
   productionCredentials: [
     string(variable: 'FASTLY_API_KEY', credentialsId:'production-terraform-fastly-api-key'),
-    file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'production-terraform-fastly-backend-config'),
+    string(variable: 'TF_BACKEND_ARM_CLIENT_SECRET', credentialsId:'production-terraform-fastly-backend-config-arm-secret'),
   ],
 )

--- a/README.adoc
+++ b/README.adoc
@@ -10,17 +10,33 @@ This repository hosts the infrastructure-as-code definition for all the link:htt
 == Requirements
 
 * A Fastly account with a personal access token defined as the value of the environment variable `FASTLY_API_KEY`
-* The requirements (of the shared tools) listed at link:{shared_tools_repo_url}/tree/main/terraform#requirements[{shared_tools_repo_name}/terraform#requirements]
-* The link:https://www.terraform.io/docs/language/settings/backends/s3.html[Terraform S3 Backend Configuration] on a local file named `backend-config`:
-** The content can be retrieved from the outputs of the link:{private_repo_url}[(private) repository {private_repo_name}]
-** This file (`backend-config`) is git-ignored
-
-* The git command line to allow cloning the repository and its submodule link:{shared_tools_repo_url}[{shared_tools_repo_name}]
-** This repository has link:https://git-scm.com/docs/git-submodule[submodules]. Once you cloned the repository, execute the following command to retrieve the shared tools:
+* The requirements (of the shared tools) listed at link:https://github.com/jenkins-infra/shared-tools/tree/main/terraform#requirements[shared-tools/terraform#requirements]
+* The link:https://github.com/jenkins-infra/shared-tools[shared-tools] common repository as a git submodule should be initialized and up-to-date:
+** On a freshly cloned Terraform repository, execute the following command to obtain the shared tools:
 
 [source,bash]
 ----
 git submodule update --init --recursive
+----
+
+** Otherwise you should update to to the latest `main` branch:
+
+[source,bash]
+----
+cd ./.shared-tools
+git pull origin main
+cd ../
+----
+
+* The Azure Credential Secret value to allow the Terraform AzureRM Backend to access remote Azure storage:
+** Must be specified in the environment variable `TF_BACKEND_ARM_CLIENT_SECRET`
+** The secret value should never be written in clear (not in a text file, not in the terminal). For instance on macOS, store it in your Keychain access and set the variable with `export TF_BACKEND_ARM_CLIENT_SECRET="$(security find-generic-password -a jenkins-tf-fastly-backend-arm-secret -w)"`
+
+* If you intend to work with the production, the environment variable `TF_VAR_environment` must be set:
+
+[source,bash]
+----
+export TF_VAR_environment=production
 ----
 
 == HowTo

--- a/backend-configs/production
+++ b/backend-configs/production
@@ -1,0 +1,5 @@
+resource_group_name  = "tf-remote-state-fastly-production-he3uyq"
+storage_account_name = "fastlyproductionhe3uyq"
+container_name       = "fastlyproductionhe3uyq"
+client_id            = "7fd8e332-4fe0-474c-a94e-ea3fc9389354"
+# client_secret      = "" # Specified through the env. variable $TF_BACKEND_ARM_CLIENT_SECRET

--- a/backend-configs/staging
+++ b/backend-configs/staging
@@ -1,0 +1,5 @@
+resource_group_name  = "tf-remote-state-fastly-staging-D4LpT5"
+storage_account_name = "fastlystagingd4lpt5"
+container_name       = "fastlystagingd4lpt5"
+client_id            = "6a12677a-06ab-4adf-8077-a14f66f7290a"
+# client_secret      = "" # Specified through the env. variable $TF_BACKEND_ARM_CLIENT_SECRET

--- a/backend.tf
+++ b/backend.tf
@@ -1,3 +1,7 @@
 terraform {
-  backend "azurerm" {}
+  backend "azurerm" {
+    subscription_id = "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
+    tenant_id       = "4c45fef2-1ba7-4120-80a0-9e2d03e9c2b6"
+    key             = "terraform.tfstate"
+  }
 }


### PR DESCRIPTION


Ref. https://github.com/jenkins-infra/helpdesk/issues/5169#issuecomment-4622327077