### PR TITLE
chore(versions) bump Terraform from `1.12.x` to `1.15.x`

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.12, <1.13"
+  required_version = ">= 1.15, <1.16"
   required_providers {
     fastly = {
       source = "fastly/fastly"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5126